### PR TITLE
Fixed null item issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <dependency>
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
-            <version>2.13.2</version>
+            <version>2.14.0</version>
             <scope>compile</scope>
         </dependency>
         <!-- MorePaperLib -->

--- a/src/main/java/xyz/geik/glib/utils/ItemUtil.java
+++ b/src/main/java/xyz/geik/glib/utils/ItemUtil.java
@@ -71,7 +71,7 @@ public class ItemUtil {
         catch (Exception e) {
             item = XMaterial.PLAYER_HEAD.parseItem();
             try {
-                XSkull.of(item).profile(Profileable.detect(material)).fallback(null).apply();
+                XSkull.of(item).profile(Profileable.detect(material)).apply();
             }
             catch (Exception ignored) {}
         }


### PR DESCRIPTION
This PR fixes null item issue while creating skull items whenever Mojang API is down. Also, it adds 1.21.3 supports.