### PR TITLE
MiniMessage support has been added, it is now available.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,22 @@
             <version>0.4.3</version>
             <scope>compile</scope>
         </dependency>
+        <!-- MiniMessage Dependencies -->
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-api</artifactId>
+            <version>4.14.0</version>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-text-minimessage</artifactId>
+            <version>4.14.0</version>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-platform-bukkit</artifactId>
+            <version>4.3.0</version>
+        </dependency>
     </dependencies>
 
     <!-- Repos -->


### PR DESCRIPTION
**Modifications for Using Minimessage and Legacy in the Farmer Plugin**

> Working Logic:

- If the text in the language file contains the "&" symbol, the plugin will automatically use the **Legacy** format. If **MiniMessage** tags are used, the plugin will automatically activate the **MiniMessage** format.